### PR TITLE
Add `as` because haxe 3.2+ allows it in place of `in`.

### DIFF
--- a/grammars/haxe.cson
+++ b/grammars/haxe.cson
@@ -241,7 +241,7 @@
     'name': 'support.constant.haxe'
   }
   {
-    'match': '\\b(case|cast|catch|default|dynamic|do|else|for|get|if|in|new|set|switch|throw|try|type|while|return|break|continue|extern|dynamic|implements|inline|override|private|public|static|import|using|package|var)\\b'
+    'match': '\\b(case|cast|catch|default|dynamic|do|else|for|get|if|in|as|new|set|switch|throw|try|type|while|return|break|continue|extern|dynamic|implements|inline|override|private|public|static|import|using|package|var)\\b'
     'name': 'keyword.control.haxe'
   }
   {


### PR DESCRIPTION
Stated here: http://haxe.org/manual/type-system-import.html
