### PR TITLE
Remove deprecated hxml arguments from snippets

### DIFF
--- a/snippets/language-haxe.cson
+++ b/snippets/language-haxe.cson
@@ -47,7 +47,7 @@
   'hxml -debug':
     'prefix': 'deb'
     'body': '-debug'
- 'hxml --each':
+  'hxml --each':
     'prefix': 'e'
     'body': '--each'
   'hxml -help':

--- a/snippets/language-haxe.cson
+++ b/snippets/language-haxe.cson
@@ -1,10 +1,4 @@
 '.source.hxml':
-  'hxml --altfmt':
-    'prefix': 'alt'
-    'body': '--altfmt'
-  'hxml --auto-xml':
-    'prefix': 'ax'
-    'body': '--auto-xml'
   'hxml --display':
     'prefix': 'dis'
     'body': '--display'
@@ -53,12 +47,6 @@
   'hxml -debug':
     'prefix': 'deb'
     'body': '-debug'
-  'hxml --each':
-    'prefix': 'e'
-    'body': '--each'
-  'hxml -exclude':
-    'prefix': 'ex'
-    'body': '-exclude ${1:file}'
   'hxml -help':
     'prefix': 'h'
     'body': '-help'

--- a/snippets/language-haxe.cson
+++ b/snippets/language-haxe.cson
@@ -47,6 +47,9 @@
   'hxml -debug':
     'prefix': 'deb'
     'body': '-debug'
+ 'hxml --each':
+    'prefix': 'e'
+    'body': '--each'
   'hxml -help':
     'prefix': 'h'
     'body': '-help'


### PR DESCRIPTION
--altfmt, --auto-xml and -exclude are no longer supported.
