### PR TITLE
Don't decrease indent for "case" and "default"

### DIFF
--- a/settings/haxe-settings.cson
+++ b/settings/haxe-settings.cson
@@ -3,4 +3,4 @@
     'commentStart': '// '
     'foldEndPattern': '^\\s*\\}|^\\s*\\]|^\\s*\\)'
     'increaseIndentPattern': '(?x)\n\t\t(\n\t\t\t\\{ [^}"\']*\n\t\t|\t\\( [^)"\']*\n\t\t|\tcase[\\s\\S]*:\n\t\t|\tdefault:\n\t\t)\n\t\t$\n\t'
-    'decreaseIndentPattern': '^(.*\\*/)?\\s*(\\}|\\)|case|default)'
+    'decreaseIndentPattern': '^(.*\\*/)?\\s*(\\}|\\))'


### PR DESCRIPTION
It is causing unwanted indent decrease for "inline cases" (i.e. `case cond: expr;` in the same line)
