### PR TITLE
Make conditional compilation keywords allow for whitespace before them.

### DIFF
--- a/grammars/haxe-grammars.cson
+++ b/grammars/haxe-grammars.cson
@@ -354,10 +354,10 @@
         'captures':
           '1':
             'name': 'keyword.control.directive.conditional.haxe'
-        'match': '(#if\\s+([\\!\\w]+|(\\([^\\)]*\\))))'
+        'match': '((\\s)*#if\\s+([\\!\\w]+|(\\([^\\)]*\\))))'
       }
       {
-        'match': '(#end|#else|#elseif)\\b'
+        'match': '(\\s)*(#end|#else|#elseif)\\b'
         'name': 'keyword.control.directive.conditional.haxe'
       }
       {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "language-haxe",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Haxe language support in Atom",
   "keywords": [
     "haxe",

--- a/spec/haxe-spec.coffee
+++ b/spec/haxe-spec.coffee
@@ -31,7 +31,7 @@ describe "Haxe Grammar", ->
         expect(grammar.fileTypes[0]).toBe "hx"
 
     describe "keywords", ->
-        keywords = ['abstract','break','case','cast','catch','class','continue','default','do','dynamic','else','enum','extern','false','for','function','if','implements','in','inline','interface','never','new','override','package','private','public','return','static','super','this','trace','true','try','typedef','untyped','using','while']
+        keywords = ['abstract','break','case','cast','catch','class','continue','default','do','dynamic','#else','else','#elseif','#end','enum','extern','false','for','function','#if','if','implements','in','inline','interface','never','new','override','package','private','public','return','static','super','this','trace','true','try','typedef','untyped','using','while']
         for keyword in keywords
             it "tokenizes the #{keyword} keyword", ->
                 {tokens} = grammar.tokenizeLine(keyword)
@@ -111,5 +111,3 @@ describe "Haxe Grammar", ->
             """
             for line in invalid.split /\n/
                 expect( grammar.firstLineRegex.scanner.findNextMatchSync( line ) ).toBeNull()
-        #it "recognises Emacs modelines", ->
-        #it "recognises Vim modelines", ->


### PR DESCRIPTION
This adds the ability to highlight syntax (and other functionality of `language-haxe` when there are spaces prefixing the `#if/#else/#elseif/#end` keywords.